### PR TITLE
Change instruction set names and casing

### DIFF
--- a/silicon-info/silicon-infoApp.swift
+++ b/silicon-info/silicon-infoApp.swift
@@ -77,9 +77,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         case NSBundleExecutableArchitectureARM64:
             architecture = "arm64 - Apple Silicon"
         case NSBundleExecutableArchitectureI386:
-            architecture = "i386 - Intel 32-bit"
+            architecture = "x86 - Intel 32-bit"
         case NSBundleExecutableArchitectureX86_64:
-            architecture = "X86-64 - Intel 64-bit"
+            architecture = "x86-64 - Intel 64-bit"
         case NSBundleExecutableArchitecturePPC:
             architecture = "ppc32 - PowerPC 32-bit"
         case NSBundleExecutableArchitecturePPC:

--- a/silicon-info/silicon-infoApp.swift
+++ b/silicon-info/silicon-infoApp.swift
@@ -75,15 +75,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         var architecture = ""
         switch architectureInt {
         case NSBundleExecutableArchitectureARM64:
-            architecture = "ARM64 - Apple Silicon"
+            architecture = "arm64 - Apple Silicon"
         case NSBundleExecutableArchitectureI386:
-            architecture = "I386 - Intel 32 bit"
+            architecture = "i386 - Intel 32-bit"
         case NSBundleExecutableArchitectureX86_64:
-            architecture = "X86_64 - Intel 64 bit"
+            architecture = "X86-64 - Intel 64-bit"
         case NSBundleExecutableArchitecturePPC:
-            architecture = "PPC - 32 bit"
+            architecture = "ppc32 - PowerPC 32-bit"
         case NSBundleExecutableArchitecturePPC:
-            architecture = "PPC - 64 bit"
+            architecture = "ppc64 - PowerPC 64-bit"
         default:
             architecture = "Unknown"
         }

--- a/silicon-info/silicon-infoApp.swift
+++ b/silicon-info/silicon-infoApp.swift
@@ -81,8 +81,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         case NSBundleExecutableArchitectureX86_64:
             architecture = "x86-64 - Intel 64-bit"
         case NSBundleExecutableArchitecturePPC:
-            architecture = "ppc32 - PowerPC 32-bit"
-        case NSBundleExecutableArchitecturePPC:
             architecture = "ppc64 - PowerPC 64-bit"
         default:
             architecture = "Unknown"


### PR DESCRIPTION
My fork changes the instruction set names to their more standardized versions. Generally, processor instruction set names don't contain uppercase letters by convention, and most people use a dash for x86-64, not an underscore. It's not wrong, just less common. Also, i386 is a line of processors, while x86 is the name of the instruction set, so I changed that too. And the PowerPC changes are pretty obvious haha.

I don't have an M1 Mac, but this project seems awesome for those who do. Definitely a great idea! Until I can get my hands on one, I'm stuck with my x64 Hackintosh lol

I deleted the 32-bit PowerPC case because it seemed that if the application was in fact a PowerPC application, it would always appear as a 32-bit PowerPC app because the case statement was checking for the same thing for both 32- and 64-bit (NSBundleExecutableArchitecturePPC).